### PR TITLE
[nvidia-bluefield] enable component versions feature for bluefield dpu

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1098,8 +1098,11 @@ sudo mkdir -p $FILESYSTEM_ROOT/etc/mlnx/cpld/
 for MLNX_CPLD_ARCHIVE in $MLNX_CPLD_ARCHIVES; do
     sudo cp $files_path/$MLNX_CPLD_ARCHIVE $FILESYSTEM_ROOT/etc/mlnx/cpld/
 done
-sudo cp platform/mellanox/get_component_versions/get_component_versions.py $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
+
+j2 platform/mellanox/get_component_versions/get_component_versions.j2 | sudo tee $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
+sudo sed -i '1d' $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
+
 sudo cp platform/mellanox/cmis_host_mgmt/cmis_host_mgmt.py $FILESYSTEM_ROOT/usr/bin/cmis_host_mgmt.py
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/cmis_host_mgmt.py
 j2 platform/mellanox/mlnx-fw-upgrade.j2 | sudo tee $FILESYSTEM_ROOT/usr/bin/mlnx-fw-upgrade.sh
@@ -1164,6 +1167,13 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/libdashapi_*.deb || \
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install xmlstarlet
 
+# Copy component-versions file
+sudo cp $files_path/$COMPONENT_VERSIONS_FILE $FILESYSTEM_ROOT/etc/mlnx/component-versions
+
+# Install current running versions script
+j2 platform/mellanox/get_component_versions/get_component_versions.j2 | sudo tee $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
+sudo sed -i '1d' $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/get_component_versions.py
 {% endif %}
 
 {%- if SONIC_ROUTING_STACK == "frr" %}

--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -1,20 +1,21 @@
+{#
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
 #!/usr/bin/env python3
-#
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 import os
 import subprocess
@@ -31,6 +32,9 @@ from tabulate import tabulate
 
 COMPONENT_VERSIONS_FILE = "/etc/mlnx/component-versions"
 HEADERS = ["COMPONENT", "COMPILATION", "ACTUAL"]
+
+{% if sonic_asic_platform == "mellanox" %}
+
 COMMANDS_FOR_ACTUAL = {
     "MFT": [["dpkg", "-l"], ["grep", "mft "], "mft *([0-9.-]*)"],
     "HW_MANAGEMENT": [["dpkg", "-l"], ["grep", "hw"], ".*1\\.mlnx\\.([0-9.]*)"],
@@ -39,6 +43,19 @@ COMMANDS_FOR_ACTUAL = {
     "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "([0-9][0-9.-]*)-.*"]
 }
+
+{% elif sonic_asic_platform == "nvidia-bluefield" %}
+
+COMMANDS_FOR_ACTUAL = {
+    "MFT": [["dpkg", "-l"], ["grep", "mft "], "mft *([0-9.-]*)"],
+    "SDK": [["docker", "exec", "syncd", "bash", "-c", 'dpkg -l | grep sdn'], "sdn-appliance *([0-9.-]*mlnx1)"],
+    "SAI": [["docker", "exec", "syncd", "bash", "-c", 'dpkg -l | grep mlnx-sai'], ".*1\\.mlnx\\.([A-Za-z0-9.]*)"],
+    "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
+    "KERNEL": [["uname", "-r"], "([0-9][0-9.-]*)-.*"],
+    "BFSOC": [["dpkg", "-l"], ["grep", "mlxbf-bootimages"], "mlxbf-bootimages *([0-9.-]*)"]
+}
+
+{% endif %}
 
 UNAVAILABLE_PLATFORM_VERSIONS = {
     "ONIE": "N/A",
@@ -53,7 +70,9 @@ UNAVAILABLE_COMPILED_VERSIONS = {
     "SAI": "N/A",
     "HW_MANAGEMENT": "N/A",
     "MFT": "N/A",
-    "KERNEL": "N/A"
+    "KERNEL": "N/A",
+    "BFSOC": "N/A",
+    "SIMX": "N/A"
 }
 
 
@@ -137,7 +156,7 @@ def main():
         output_table.append([comp, compiled_versions[comp], actual])
 
     # Handle if SIMX
-    if DeviceDataManager.is_simx_platform():
+    if hasattr(DeviceDataManager, "is_simx_platform") and DeviceDataManager.is_simx_platform():
         simx_actual_ver = DeviceDataManager.get_simx_version()
         output_table.append(["SIMX", simx_compiled_ver, simx_actual_ver])
         platform_versions = UNAVAILABLE_PLATFORM_VERSIONS

--- a/platform/nvidia-bluefield/component-versions/Makefile
+++ b/platform/nvidia-bluefield/component-versions/Makefile
@@ -1,0 +1,27 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+.ONESHELL:
+SHELL = /bin/bash
+.SHELLFLAGS += -e
+
+MAIN_TARGET = component-versions
+
+$(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
+	bash -e create_component_versions.sh 
+	mv temp_versions_file $(DEST)/$(MAIN_TARGET)

--- a/platform/nvidia-bluefield/component-versions/create_component_versions.sh
+++ b/platform/nvidia-bluefield/component-versions/create_component_versions.sh
@@ -1,0 +1,24 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "SDK $SDK_VERSION" > temp_versions_file
+echo "FW $BF3_FW_VERSION" >> temp_versions_file
+echo "SAI $DPU_SAI_VERSION" >> temp_versions_file
+echo "BFSOC $BFSOC_VERSION-$BFSOC_REVISION" >> temp_versions_file
+echo "MFT $MFT_VERSION-$MFT_REVISION" >> temp_versions_file
+echo "KERNEL $KVERSION_SHORT" >> temp_versions_file

--- a/platform/nvidia-bluefield/recipes/component-versions.mk
+++ b/platform/nvidia-bluefield/recipes/component-versions.mk
@@ -1,0 +1,23 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+COMPONENT_VERSIONS_FILE = component-versions
+$(COMPONENT_VERSIONS_FILE)_SRC_PATH = $(PLATFORM_PATH)/component-versions
+SONIC_MAKE_FILES += $(COMPONENT_VERSIONS_FILE)
+
+export COMPONENT_VERSIONS_FILE

--- a/platform/nvidia-bluefield/recipes/fw.mk
+++ b/platform/nvidia-bluefield/recipes/fw.mk
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +38,7 @@ endif
 
 BF_FW_FILES = $(BF3_FW_FILE)
 
+export BF3_FW_VERSION
 export BF3_FW_FILE
 export BF_FW_FILES
 

--- a/platform/nvidia-bluefield/recipes/installer-image.mk
+++ b/platform/nvidia-bluefield/recipes/installer-image.mk
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +57,7 @@ SONIC_PACKAGES_LOCAL := $(filter-out $(DISABLED_PACKAGES_LOCAL), $(SONIC_PACKAGE
 $(foreach feature, $(DISABLED_FEATURE_FLAGS), $(eval override $(feature)=n ))
 
 $(SONIC_BF_IMAGE_BASE)_DOCKERS = $(filter-out $(DISABLED_DOCKERS), $(SONIC_INSTALL_DOCKER_IMAGES))
-$(SONIC_BF_IMAGE_BASE)_FILES = $(BF_FW_FILES)
+$(SONIC_BF_IMAGE_BASE)_FILES = $(BF_FW_FILES) $(COMPONENT_VERSIONS_FILE)
 
 # The traditional *.bin image. Works for sonic-sonic upgrade.
 SONIC_BF_IMAGE_BIN = $(SONIC_BF_IMAGE_BASE).bin

--- a/platform/nvidia-bluefield/rules.mk
+++ b/platform/nvidia-bluefield/rules.mk
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +28,7 @@ include $(PLATFORM_PATH)/$(RECIPE_DIR)/sdk.mk
 include $(PLATFORM_PATH)/$(RECIPE_DIR)/platform-api.mk
 include $(PLATFORM_PATH)/$(RECIPE_DIR)/docker-syncd-bluefield.mk
 include $(PLATFORM_PATH)/$(RECIPE_DIR)/installer-image.mk
+include $(PLATFORM_PATH)/$(RECIPE_DIR)/component-versions.mk
 
 # Inject DPU sai into syncd
 $(SYNCD)_DEPENDS += $(DPU_SAI)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To enable users to check the compiled versions of various sonic components and the current running versions on the bluefield dpu. Similar to [component-version-listing PR](https://github.com/sonic-net/sonic-buildimage/pull/18591/files) 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- I exported necessary environment variables for the compiled component versions from the corresponding Makefiles. I used a Makefile to write these into a new "component-versions" file. 
- I also converted existing get_component_versions.py script into a jinja2 template that works both for mellanox and bluefield-dpu platforms

#### How to verify it
- cat /etc/mlnx/component-versions will give the compiled versions
- get_component_versions.py will give a comparison between compiled versions and the currently running versions

Obtaining component-versions on a bluefield-dpu
```
root@sonic:/home/admin# get_component_versions.py
COMPONENT      COMPILATION       ACTUAL
-------------  ----------------  ----------------
SDK            25.1-RC8          1.5-1mlnx1
FW             43.1014           43.1014
SAI            SAIBuild0.0.39.0  SAIBuild0.0.39.0
HW_MANAGEMENT  N/A               N/A
MFT            4.28.0-96         4.28.0-96
KERNEL         6.1.0-22-2        6.1.0-22-2
BFSOC          4.10.0-13520      4.10.0-13520
ONIE           -                 N/A
SSD            -                 N/A
BIOS           -                 N/A
CPLD           -                 N/A
root@sonic:/home/admin# cat /etc/mlnx/component-versions
SDK 25.1-RC8
FW 43.1014
SAI SAIBuild0.0.39.0
BFSOC 4.10.0-13520
MFT 4.28.0-96
KERNEL 6.1.0-22-2
```
Obtaining component-versions on a switch
```
root@r-bobcat-03:/home/admin# cat /etc/mlnx/component-versions
SDK 4.7.2202
FW 2014.2202
SAI SAIBuild2411.2405.30.1
HW_MANAGEMENT 7.0040.2104
MFT 4.30.2-23
KERNEL 6.1.0-22-2
SIMX 25.1-1070
root@r-bobcat-03:/home/admin# get_component_versions.py
COMPONENT      COMPILATION             ACTUAL
-------------  ----------------------  ----------------------
SDK            4.7.2202                4.7.2202
FW             2014.2202               2014.2202
SAI            SAIBuild2411.2405.30.1  SAIBuild2411.2405.30.1
HW_MANAGEMENT  7.0040.2104             7.0040.2104
MFT            4.30.2-23               4.30.2-23
KERNEL         6.1.0-22-2              6.1.0-22-2
BFSOC          N/A                     N/A
ONIE           -                       2023.11-5.3.0012-9600
SSD            -                       CE00A400
BIOS           -                       0ACTV_00.00.019_9600
CPLD1          -                       CPLD000370_REV0104
CPLD2          -                       CPLD060387_REV0104
CPLD3          -                       CPLD000388_REV0100
DPU1_FPGA      -                       FPGA000375_REV0006
DPU2_FPGA      -                       FPGA000375_REV0006
DPU3_FPGA      -                       FPGA000375_REV0006
DPU4_FPGA      -                       FPGA000375_REV0006
```

#### Known Issues
- The current version of sdk on the dpu is taken from the sdn-appliance field and is a known issue. 
- Fix Date: TBD

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

