### PR TITLE
Remove BFSOC version displayed in mellanox platforms

### DIFF
--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -44,6 +44,16 @@ COMMANDS_FOR_ACTUAL = {
     "KERNEL": [["uname", "-r"], "([0-9][0-9.-]*)-.*"]
 }
 
+UNAVAILABLE_COMPILED_VERSIONS = {
+    "SDK": "N/A",
+    "FW": "N/A",
+    "SAI": "N/A",
+    "HW_MANAGEMENT": "N/A",
+    "MFT": "N/A",
+    "KERNEL": "N/A",
+    "SIMX": "N/A"
+}
+
 {% elif sonic_asic_platform == "nvidia-bluefield" %}
 
 COMMANDS_FOR_ACTUAL = {
@@ -55,6 +65,16 @@ COMMANDS_FOR_ACTUAL = {
     "BFSOC": [["dpkg", "-l"], ["grep", "mlxbf-bootimages"], "mlxbf-bootimages *([0-9.-]*)"]
 }
 
+UNAVAILABLE_COMPILED_VERSIONS = {
+    "SDK": "N/A",
+    "FW": "N/A",
+    "SAI": "N/A",
+    "MFT": "N/A",
+    "KERNEL": "N/A",
+    "BFSOC": "N/A",
+    "SIMX": "N/A"
+}
+
 {% endif %}
 
 UNAVAILABLE_PLATFORM_VERSIONS = {
@@ -64,16 +84,6 @@ UNAVAILABLE_PLATFORM_VERSIONS = {
     "CPLD": "N/A"
 }
 
-UNAVAILABLE_COMPILED_VERSIONS = {
-    "SDK": "N/A",
-    "FW": "N/A",
-    "SAI": "N/A",
-    "HW_MANAGEMENT": "N/A",
-    "MFT": "N/A",
-    "KERNEL": "N/A",
-    "BFSOC": "N/A",
-    "SIMX": "N/A"
-}
 
 
 def parse_compiled_components_file():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To remove BFSOC: N/A version displayed in get_component_versions.py output in mellanox platforms and remove HW_MANAGEMENT: N/A version displayed in nvidia-bluefield dpu platforms. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update get_component_versions.j2 jinja template to generate different UNAVAILABLE_COMPILED_VERSIONS based on the platform

#### How to verify it

Run get_component_versions.py on the switch

##### SWITCH: Before
```
root@switch:/home/admin# get_component_versions.py
COMPONENT      COMPILATION             ACTUAL
-------------  ----------------------  -------------------------
SDK            4.7.2214                4.7.2214
FW             2014.2214               2014.2214
SAI            SAIBuild2411.2405.30.1  SAIBuild2411.2405.30.1
HW_MANAGEMENT  7.0040.2207             7.0040.2207
MFT            4.30.2-23               4.30.2-23
KERNEL         6.1.0-22-2              6.1.0-22-2
BFSOC          N/A                     N/A
ONIE           -                       2024.08-5.3.0015-9600-dev
SSD            -                       CE00A400
BIOS           -                       0ACTV_00.01.013_9600
CPLD1          -                       CPLD000370_REV0500
CPLD2          -                       CPLD000387_REV0500
CPLD3          -                       CPLD000388_REV0200
DPU1_FPGA      -                       FPGA000375_REV0200
DPU2_FPGA      -                       FPGA000375_REV0200
DPU3_FPGA      -                       FPGA000375_REV0200
DPU4_FPGA      -                       FPGA000375_REV0200
```

##### SWITCH: After

- BFSOC is removed below for the Mellanox Platform Switch
```
root@switch:/home/admin# get_component_versions.py
COMPONENT      COMPILATION             ACTUAL
-------------  ----------------------  -------------------------
SDK            4.7.2214                4.7.2214
FW             2014.2214               2014.2214
SAI            SAIBuild2411.2405.30.1  SAIBuild2411.2405.30.1
HW_MANAGEMENT  7.0040.2104             7.0040.2104
MFT            4.30.2-23               4.30.2-23
KERNEL         6.1.0-22-2              6.1.0-22-2
ONIE           -                       2024.08-5.3.0015-9600-dev
SSD            -                       CE00A400
BIOS           -                       0ACTV_00.01.013_9600
CPLD1          -                       CPLD000370_REV0500
CPLD2          -                       CPLD000387_REV0500
CPLD3          -                       CPLD000388_REV0200
DPU1_FPGA      -                       FPGA000375_REV0200
DPU2_FPGA      -                       FPGA000375_REV0200
DPU3_FPGA      -                       FPGA000375_REV0200
DPU4_FPGA      -                       FPGA000375_REV0200

```

##### DPU: Before

```
root@dpu:/home/admin# get_component_versions.py
COMPONENT      COMPILATION       ACTUAL
-------------  ----------------  ----------------
SDK            25.4-RC3          1.5-1mlnx1
FW             45.0322           45.0322
SAI            SAIBuild0.0.41.0  SAIBuild0.0.41.0
HW_MANAGEMENT  N/A               N/A
MFT            4.30.2-23         4.30.2-23
KERNEL         6.1.0-22-2        6.1.0-22-2
BFSOC          4.11.0-13582      4.11.0-13582
ONIE           -                 N/A
SSD            -                 N/A
BIOS           -                 N/A
CPLD           -                 N/A
```

##### DPU: After

```
root@dpu:~# get_component_versions.py
COMPONENT    COMPILATION       ACTUAL
-----------  ----------------  ----------------
SDK          25.4-RC3          1.5-1mlnx1
FW           45.0322           45.0322
SAI          SAIBuild0.0.41.0  SAIBuild0.0.41.0
MFT          4.30.2-23         4.30.2-23
KERNEL       6.1.0-22-2        6.1.0-22-2
BFSOC        4.11.0-13582      4.11.0-13582
ONIE         -                 N/A
SSD          -                 N/A
BIOS         -                 N/A
CPLD         -                 N/A
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

