### PR TITLE
[Trixie] Patch grub 2.12-9 to support linuexfi and initrdefi commands and integrate into sonic

### DIFF
--- a/rules/grub.dep
+++ b/rules/grub.dep
@@ -1,0 +1,12 @@
+
+SPATH       := $($(GRUB2_COMMON)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/grub.mk rules/grub.dep 
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(SPATH))
+
+$(GRUB2_COMMON)_CACHE_MODE           := GIT_CONTENT_SHA 
+
+$(GRUB2_COMMON)_DEP_FLAGS           := $(SONIC_COMMON_FLAGS_LIST)
+
+$(GRUB2_COMMON)_DEP_FILES           := $(DEP_FILES)
+

--- a/rules/grub.mk
+++ b/rules/grub.mk
@@ -1,0 +1,42 @@
+# grub2 package
+
+GRUB2_VERSION = 2.12-9
+GRUB2_VERSION_BASE = 2.12
+export GRUB2_VERSION_BASE
+export GRUB2_VERSION
+
+# Debian source builds multiple binary packages; export the key ones we consume
+# Pick one as the MAIN package - let's use GRUB2_COMMON
+GRUB2_COMMON          = grub2-common_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(GRUB2_COMMON)_SRC_PATH = $(SRC_PATH)/grub
+SONIC_MAKE_DEBS += $(GRUB2_COMMON)
+
+# All others are DERIVED packages (built by the same dpkg-buildpackage)
+# Use add_derived_package to properly register them with the build system
+GRUB_COMMON           = grub-common_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_COMMON)))
+
+GRUB_EFI_META         = grub-efi_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_META)))
+
+GRUB_EFI_ARCH         = grub-efi-$(CONFIGURED_ARCH)_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_ARCH)))
+
+GRUB_EFI_ARCH_BIN     = grub-efi-$(CONFIGURED_ARCH)-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_ARCH_BIN)))
+
+GRUB_EFI_ARCH_UNSIGNED= grub-efi-$(CONFIGURED_ARCH)-unsigned_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_ARCH_UNSIGNED)))
+
+## BIOS tools for x86 (only for amd64 builds)
+ifeq ($(CONFIGURED_ARCH),amd64)
+GRUB_PC_BIN           = grub-pc-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_PC_BIN)))
+endif
+
+# Export all packages for use in build_debian.sh and src/grub/Makefile
+GRUB_DEBS = $(GRUB2_COMMON) $(GRUB_COMMON) $(GRUB_EFI_META) $(GRUB_EFI_ARCH) $(GRUB_EFI_ARCH_BIN) $(GRUB_EFI_ARCH_UNSIGNED) $(GRUB_PC_BIN)
+export GRUB_DEBS
+export GRUB2_COMMON GRUB_COMMON GRUB_EFI_META GRUB_EFI_ARCH GRUB_EFI_ARCH_BIN GRUB_EFI_ARCH_UNSIGNED GRUB_PC_BIN
+
+

--- a/slave.mk
+++ b/slave.mk
@@ -1342,6 +1342,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
         .platform \
         build_debian.sh \
         $(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_KERNEL)) \
+        $(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(GRUB_DEBS)) \
         $$(addprefix $(TARGET_PATH)/,$$($$*_DEPENDENT_RFS)) \
         $(call dpkg_depend,$(TARGET_PATH)/%.dep)
 	$(HEADER)

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -605,6 +605,9 @@ RUN eatmydata apt-get install -y xsltproc
 # Install dependencies for isc-dhcp-relay build
 RUN eatmydata apt-get -y build-dep isc-dhcp
 
+# Install dependencies for grub2
+RUN eatmydata apt-get -y build-dep grub2
+
 # Install vim
 RUN eatmydata apt-get install -y vim
 

--- a/src/grub/Makefile
+++ b/src/grub/Makefile
@@ -1,0 +1,33 @@
+.ONESHELL:
+SHELL = /bin/bash
+.SHELLFLAGS += -e
+
+MAIN_TARGET = $(GRUB2_COMMON)
+DERIVED_TARGETS = $(GRUB_COMMON) $(GRUB_EFI_META) $(GRUB_EFI_ARCH) $(GRUB_EFI_ARCH_BIN) $(GRUB_EFI_ARCH_UNSIGNED) $(GRUB_PC_BIN)
+
+$(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
+	# Remove any stale files
+	rm -rf ./grub2-$(GRUB2_VERSION_BASE)*
+
+	# Get grub2 release
+	dget https://deb.debian.org/debian/pool/main/g/grub2/grub2_$(GRUB2_VERSION).dsc
+	pushd ./grub2-$(GRUB2_VERSION_BASE)
+
+	git init
+	git add -f *
+	git commit -m "unmodified grub2 source"
+
+	# Apply patches
+	stg init
+	stg import -s ../patch/series
+
+	# Build source and Debian packages
+ifeq ($(CROSS_BUILD_ENVIRON), y)
+	dpkg-buildpackage -rfakeroot -b -us -uc -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS)  --admindir $(SONIC_DPKG_ADMINDIR)
+else
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
+endif
+	popd
+
+	# Move ALL the newly-built .deb packages to the destination directory
+	mv $(DERIVED_TARGETS) $(MAIN_TARGET) $(DEST)/

--- a/src/grub/patch/0001-Add-linuxefi-and-initrdefi-command-support.patch
+++ b/src/grub/patch/0001-Add-linuxefi-and-initrdefi-command-support.patch
@@ -1,0 +1,41 @@
+From e0ad18658a06d6428e7f2728eec03d63dfed5527 Mon Sep 17 00:00:00 2001
+From: Hemanth Kumar Tirupati <htirupati@nvidia.com>
+Date: Thu, 16 Oct 2025 07:15:44 +0000
+Subject: [PATCH] Add linuxefi and initrdefi command support
+
+---
+ grub-core/loader/efi/linux.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
+index bfbd95aee..b60879d98 100644
+--- a/grub-core/loader/efi/linux.c
++++ b/grub-core/loader/efi/linux.c
+@@ -576,6 +576,7 @@ fail:
+ 
+ 
+ static grub_command_t cmd_linux, cmd_initrd;
++static grub_command_t cmd_linuxefi, cmd_initrdefi;
+ 
+ GRUB_MOD_INIT (linux)
+ {
+@@ -583,6 +584,9 @@ GRUB_MOD_INIT (linux)
+ 				     N_("Load Linux."));
+   cmd_initrd = grub_register_command ("initrd", grub_cmd_initrd, 0,
+ 				      N_("Load initrd."));
++
++  cmd_linuxefi = grub_register_command("linuxefi", grub_cmd_linux, 0, N_("Load Linux."));
++  cmd_initrdefi = grub_register_command("initrdefi", grub_cmd_initrd, 0, N_("Load initrd."));
+   my_mod = mod;
+ }
+ 
+@@ -590,4 +594,6 @@ GRUB_MOD_FINI (linux)
+ {
+   grub_unregister_command (cmd_linux);
+   grub_unregister_command (cmd_initrd);
++  grub_unregister_command (cmd_linuxefi);
++  grub_unregister_command (cmd_initrdefi);
+ }
+-- 
+2.50.1
+

--- a/src/grub/patch/0002-Remove-p-option-to-dh_auto_build.patch
+++ b/src/grub/patch/0002-Remove-p-option-to-dh_auto_build.patch
@@ -1,0 +1,25 @@
+From 308165dd8ec1f982cb519b55752399ee08b1ecf8 Mon Sep 17 00:00:00 2001
+From: root <root@s-build-sonic-01.mts.labs.mlnx>
+Date: Fri, 17 Oct 2025 03:52:43 +0000
+Subject: [PATCH] Remove p option to dh_auto_build
+
+---
+ debian/rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/rules b/debian/rules
+index 7a9414f..fe021ff 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -177,7 +177,7 @@ debian/stamps/configure-%: package = $(subst debian/stamps/configure-,,$@)
+ debian/stamps/configure-%: export DH_OPTIONS = -p$(package) -Bobj/$(package)
+ 
+ debian/stamps/build-%: package = $(subst debian/stamps/build-,,$@)
+-debian/stamps/build-%: export DH_OPTIONS = -p$(package) -Bobj/$(package)
++debian/stamps/build-%: export DH_OPTIONS = -Bobj/$(package)
+ 
+ install/%: package = $(subst install/,,$@)
+ install/%: package_bin = $(package)-bin
+-- 
+2.50.1
+

--- a/src/grub/patch/series
+++ b/src/grub/patch/series
@@ -1,0 +1,2 @@
+0001-Add-linuxefi-and-initrdefi-command-support.patch
+0002-Remove-p-option-to-dh_auto_build.patch


### PR DESCRIPTION
Patch grub 2.12-9 to support linuexfi and initrdefi commands and integrate the patched grub into sonic

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Debian 13 Trixie comes with grub 2.12-9 which doesn't have support for 'linuxefi' and 'initrdefi' command. Further this is incompatible with grub that comes with onie 2.04

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Build grub from the source patch to add backwards compatibility support for 'linuxefi' and 'initrdefi'
#### How to verify it
Install the Debian 13 Trixie image on a secure boot enabled system.

