### PR TITLE
[Smartswitch] Kill stale initramfs udevd process before updating udevd rules

### DIFF
--- a/platform/mellanox/smartswitch/dpu-udev-manager/dpu-udev-manager.sh
+++ b/platform/mellanox/smartswitch/dpu-udev-manager/dpu-udev-manager.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,28 @@ declare -r platform_json="/usr/share/sonic/device/$platform/platform.json"
 
 declare -r query='.DPUS | to_entries[] | "\(.key) \(.value.bus_info)"'
 
+# Kill any stale initramfs udevd that survived switch_root.
+# During boot, the initramfs starts systemd-udevd before the overlayfs root is
+# created. If device firmware init is slow (e.g. DPU FW timeout), udevd workers
+# block and the initramfs cannot stop udevd before switch_root. The stale
+# process ends up with a broken root filesystem view (its root still points to
+# the initramfs rootfs, not the overlayfs). Writing udev rules below triggers
+# the stale udevd to access file system for the updated rules which crashes
+# because dir_fd_is_root() triggers assertion failure for a
+# non-chrooted process in systemd.
+kill_stale_udevd() {
+    local sysd_pid
+    sysd_pid=$(systemctl show systemd-udevd -p MainPID --value 2>/dev/null)
+    for pid in $(pgrep -f "systemd-udevd --daemon"); do
+        if [ "$pid" != "$sysd_pid" ]; then
+            logger "dpu-udev-manager: killing stale initramfs udevd PID $pid (systemd udevd is PID $sysd_pid)"
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+}
+
 do_start() {
+    kill_stale_udevd
     jq -r "$query" $platform_json | while read -r dpu bus_info; do
         echo SUBSYSTEM==\"net\", ACTION==\"add\", KERNELS==\"$bus_info\", NAME=\"$dpu\"
     done > $udev_file

--- a/platform/mellanox/smartswitch/dpu-udev-manager/dpu-udev-manager.sh
+++ b/platform/mellanox/smartswitch/dpu-udev-manager/dpu-udev-manager.sh
@@ -1,6 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On SONiC SmartSwitch platforms with DPUs, systemd-udevd crashes with SIGABRT on every reboot when DPU firmware initialization is slow. During the initramfs boot phase, a standalone systemd-udevd daemon is started to handle device discovery. If DPU firmware takes longer than the 60-second udevadm settle timeout (BlueField-3 DPUs can take 120 seconds each in the failure case when they are stuck), the initramfs cannot stop this udevd before switch_root. The stale process survives into the real system but is never chrooted into the overlayfs root, leaving it with a broken filesystem view. When dpu-udev-manager.sh writes udev rules, the stale udevd detects the change and crashes on an assertion in systemd's chase() path resolution (assert(path_is_absolute(p)) at chase.c:648), because dir_fd_is_root() returns false for a process whose root still points to the initramfs rootfs rather than the overlayfs. 

This triggers a systemd issue : systemd#29559 which maintainers doesn't consider as a bug from systemd side. Raising this fix for our usecase.

```
Core was generated by `/usr/lib/systemd/systemd-udevd --daemon --resolve-names=never'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f29fe7f695c in ?? () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007f29fe7f695c in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f29fe7a1cc2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f29fe78a4ac in abort () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f29fea50c11 in ?? () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#4  0x00007f29feb94a8b in chase () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#5  0x00007f29feb956e2 in chase_and_opendir () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#6  0x00007f29feb9a609 in conf_files_list_strv () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#7  0x00007f29fea913e8 in config_get_stats_by_path () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#8  0x0000559f295519cf in ?? ()
#9  0x0000559f29553a77 in ?? ()
#10 0x00007f29fec36055 in ?? () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#11 0x00007f29fec3668d in sd_event_dispatch () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#12 0x00007f29fec394a8 in sd_event_run () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#13 0x00007f29fec396c7 in sd_event_loop () from /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-257.so
#14 0x0000559f29545820 in ?? ()
#15 0x00007f29fe78bca8 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#16 0x00007f29fe78bd65 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#17 0x0000559f29545c51 in ?? ()

```


#### How I did it
Added a kill_stale_udevd() function to dpu-udev-manager.sh that runs before writing the udev rules. It identifies the systemd-managed udevd PID via systemctl show, then kills any other systemd-udevd --daemon process that doesn't match -- these are leftover initramfs instances. If no stale process exists (e.g. DPUs are healthy and the initramfs udevd exited cleanly), the function is a no-op.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
- Deploy the image on a SmartSwitch with DPUs in a state where firmware initialization times out (>60s per DPU) by stopping image installation before firmware install step
- Reboot the switch
- Verify no new systemd-udevd coredumps in /var/core/
- Verify the stale process was killed: journalctl -b 0 | grep dpu-udev-manager should show killing stale initramfs udevd PID <X> (systemd udevd is PID <Y>)
- Verify systemd-udevd.service is healthy: systemctl status systemd-udevd should show active (running)
- Verify DPU udev rules were written: cat /etc/udev/rules.d/92-midplane-intf.rules should contain the DPU interface naming rules


