### PR TITLE
[Trixie] Fix missing linux-kbuild in RFS split build second stage

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -628,6 +628,10 @@ if [[ $RFS_SPLIT_LAST_STAGE == y ]]; then
 
     trap_push 'sudo LANG=C chroot $FILESYSTEM_ROOT umount /proc || true'
     sudo LANG=C chroot $FILESYSTEM_ROOT mount proc /proc -t proc
+
+    ## Install kbuild for sign-file into docker image (not fsroot), needed for secure boot signing.
+    ## The RFS first stage installs kbuild that may no longer exist when only second stage executes.
+    sudo LANG=C DEBIAN_FRONTEND=noninteractive apt -y --allow-downgrades install ./$debs_path/linux-kbuild-${LINUX_KERNEL_VERSION}*_${CONFIGURED_ARCH}.deb
 fi
 
 ## Version file part 2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When build_debian.sh runs as the second stage (RFS_SPLIT_LAST_STAGE=y), the linux-kbuild package is not installed in the docker slave because its installation at [line 169 ](https://github.com/sonic-net/sonic-buildimage/blob/14d4604149c41a69589494d0430bc34c688bcb16/build_debian.sh#L169) is inside the first-stage-only block. If the RFS squashfs was already built (e.g., by a previous attempt that failed for an unrelated reason), Make skips the RFS recipe on retry, and the second stage fails during secure boot kernel module signing:

```
ERROR: LOCAL_SIGN_FILE=/usr/lib/linux-kbuild-6.12.41+deb13/scripts/sign-file file does not exist
```
This happens because the RFS target and docker targets are independent siblings built in parallel. If a docker build fails but the RFS succeeds, the squashfs persists on disk. On retry, Make considers the RFS up-to-date and skips it, so linux-kbuild is never installed, and the installer's second stage cannot sign kernel modules.

NOTE: This is seen primarily after Host Trixie upgrade because we don't install linux-kbuild as part of sonic-slave-trixie container

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added linux-kbuild installation to the RFS_SPLIT_LAST_STAGE=y section of build_debian.sh, ensuring the sign-file tool is available for secure boot signing regardless of whether the first stage ran in the current build invocation.

#### How to verify it
Trigger a build with SECURE_UPGRADE_MODE=dev where the RFS squashfs already exists from a prior attempt (e.g., retry after a transient docker build failure). Verify that the installer stage completes kernel module signing successfully.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ X] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

