### PR TITLE
[Mellanox] Fix mlnx-fw-manager service ordering to prevent boot-time firmware query failures

### DIFF
--- a/platform/mellanox/files/mlnx-fw-manager.service
+++ b/platform/mellanox/files/mlnx-fw-manager.service
@@ -18,6 +18,8 @@
 
 [Unit]
 Description=Mellanox Firmware Manager Service
+After=sonic.target
+Wants=sx-kernel.service
 
 [Service]
 Type=oneshot
@@ -26,6 +28,10 @@ ExecStartPre=/usr/bin/mst start --with_i2cdev
 ExecStart=/usr/local/bin/mlnx-fw-manager --clear-semaphore --verbose
 ExecStop=/usr/bin/mst stop
 TimeoutSec=300
+Restart=on-failure
+RestartSec=10
+StartLimitIntervalSec=120
+StartLimitBurst=3
 User=root
 
 [Install]

--- a/platform/mellanox/files/sx-kernel.service
+++ b/platform/mellanox/files/sx-kernel.service
@@ -18,6 +18,7 @@
 
 [Unit]
 Description=SX Kernel Driver Service
+Requires=mlnx-fw-manager.service
 After=mlnx-fw-manager.service
 
 [Service]


### PR DESCRIPTION
## Why I did it

After PR 25064 refactored the Mellanox firmware manager from an inline bash script (called from `syncd.sh`) into a standalone systemd service (`mlnx-fw-manager.service`), the firmware query (`mlxfwmanager --query-format XML`) can fail on boot because the service starts too early — before the ASIC PCI device is ready to respond.

The old flow ran the firmware check from within `syncd.sh`, which naturally started ~14 seconds into boot due to its dependency chain (`database.service` → `config-setup.service` → `sonic.target`). The new `mlnx-fw-manager.service` has no `After=` ordering and starts at ~0 seconds into the systemd boot sequence, racing ahead of basic system initialization.

Additionally, `sx-kernel.service` (which loads `sxd_kernel` and triggers a full ASIC chip reset) has only `After=mlnx-fw-manager.service` without `Requires=`. When `mlnx-fw-manager` fails, `sx-kernel` starts anyway, and the chip reset it triggers blocks all subsequent firmware query retries.

Evidence from syslog showing the service starts at the same instant as kernel message flush, well before `sonic.target` is reached:

```
07:19:17.979 sonic kernel: Command line: BOOT_IMAGE=...
07:19:17.980 sonic kernel: pci 0000:07:00.0: [15b3:cf70] type 00 class 0x020000 PCIe Endpoint
07:19:17.980 sonic systemd[1]: Starting mlnx-fw-manager.service - Mellanox Firmware Manager Service...
07:19:19.065 sonic mlnx-fw-manager[1704]: Unable to get firmware versions (attempt 1/10): Query returned non-zero exit code, retrying...
  ... all 10 attempts fail ...
07:19:28.171 sonic mlnx-fw-manager[1704]: Failed to get firmware versions after 10 attempts
07:19:28.204 sonic systemd[1]: Failed to start mlnx-fw-manager.service
07:19:28.208 sonic systemd[1]: Starting sx-kernel.service    <-- starts despite fw-manager failure
07:19:29.211 sonic systemd[1]: Reached target sonic.target   <-- sonic.target reached AFTER failure
07:19:35.390 sonic kernel: sxd_kernel: performing chip reset  <-- blocks subsequent retries
```

For comparison, `sonic.target` is reached at 07:19:29 and the `database.service` starts at 07:19:23 — both well after the firmware manager has already failed.

## How I did it

Two changes to the systemd service files:

**1. `mlnx-fw-manager.service`** — Add `After=sonic.target` to delay the service until the system has progressed far enough in the boot sequence (matching the old flow's effective timing). Add `Wants=sx-kernel.service` so that on restart, `sx-kernel` is pulled in. Add `Restart=on-failure` with `RestartSec=10` as a safety net for slower hardware.

```ini
[Unit]
Description=Mellanox Firmware Manager Service
After=sonic.target
Wants=sx-kernel.service

[Service]
Type=oneshot
RemainAfterExit=yes
ExecStartPre=/usr/bin/mst start --with_i2cdev
ExecStart=/usr/local/bin/mlnx-fw-manager --clear-semaphore --verbose
ExecStop=/usr/bin/mst stop
TimeoutSec=300
Restart=on-failure
RestartSec=10
StartLimitIntervalSec=120
StartLimitBurst=3
User=root
```

**2. `sx-kernel.service`** — Add `Requires=mlnx-fw-manager.service` so that `sx-kernel` only starts when `mlnx-fw-manager` succeeds, preventing the `sxd_kernel` chip reset from blocking retry attempts.

```ini
[Unit]
Description=SX Kernel Driver Service
Requires=mlnx-fw-manager.service
After=mlnx-fw-manager.service
```

The resulting dependency chain is linear with no circular dependencies:

```
sonic.target → mlnx-fw-manager.service → sx-kernel.service → syncd.service
```

## How to verify it

1. Install the image on a Mellanox switch and reboot.
2. Check syslog to confirm `mlnx-fw-manager.service` starts **after** `sonic.target` is reached:
   ```
   grep -E 'sonic.target|mlnx-fw-manager|sx-kernel' /var/log/syslog | head -20
   ```
3. Confirm the firmware query succeeds with zero or minimal retries (no "Unable to get firmware versions" messages).
4. Confirm `mlnx-fw-manager.service` exits with code 0 and `sx-kernel.service` starts only after it succeeds.
5. Confirm all dockers are up: `docker ps --format '{{.Names}}' | sort` — bgp, radv, snmp, swss should all be present.
6. To test the retry safety net: temporarily add a short sleep before `mlxfwmanager` in the Python code to force a first-attempt failure, reboot, and verify the service auto-restarts and succeeds on the second attempt with `sx-kernel` starting afterward.