### PR TITLE
[Mellanox] Add debug env flags and exponential backoff for FW query

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -263,38 +263,72 @@ class FirmwareManagerBase(Process):
             FirmwareManagerError: If query fails or versions cannot be retrieved
         """
         cmd = ['mlxfwmanager', '--query-format', 'XML', '-d', self.pci_id]
-        result = self._run_command(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise FirmwareManagerError("Query returned non-zero exit code")
+        env = self._get_env()
+        result = self._run_command(cmd, env=env, capture_output=True, text=True)
 
-        root = ET.fromstring(result.stdout)
+        output = result.stdout or ''
+
+        if result.returncode != 0:
+            raise FirmwareManagerError(f"Query returned non-zero exit code: {output}")
+
+        # Extract XML block from potentially verbose debug output
+        xml_start = output.find('<Devices>')
+        xml_end = output.find('</Devices>')
+        if xml_start < 0 or xml_end < 0:
+            raise FirmwareManagerError(f"No XML device data found in query output: {output}")
+
+        xml_str = output[xml_start:xml_end + len('</Devices>')]
+        root = ET.fromstring(xml_str)
         current_version = root.find('.//Device/Versions/FW').get('current')
         psid = root.find('.//Device').get('psid')
 
-        if not current_version or not psid:
-            raise FirmwareManagerError("Version or PSID not found in response")
+        if not current_version or current_version == '--' or not psid:
+            raise FirmwareManagerError(f"Version or PSID not found in response: {output}")
 
         available_version = self._get_available_firmware_version(psid)
         return current_version, available_version
 
     def _get_firmware_versions(self) -> Tuple[Optional[str], Optional[str]]:
-        """Get current and available firmware versions with retry logic."""
-        query_retry_count = 0
-        query_retry_count_max = 10
+        """Get current and available firmware versions with exponential backoff retry."""
+        max_wait = 60
+        delay = 1
+        max_delay = 16
+        start_time = time.monotonic()
+        attempt = 0
 
-        while query_retry_count < query_retry_count_max:
+        while True:
+            attempt += 1
             try:
                 return self._query_firmware_versions()
             except Exception as e:
-                if query_retry_count >= query_retry_count_max - 1:
-                    self.logger.error(f"Failed to get firmware versions after {query_retry_count_max} attempts: {str(e)}")
+                elapsed = time.monotonic() - start_time
+                remaining = max_wait - elapsed
+
+                if remaining <= 0:
+                    self.logger.error(
+                        f"Failed to get firmware versions for {self.pci_id} "
+                        f"after {attempt} attempts ({elapsed:.0f}s elapsed): {str(e)}"
+                    )
                     return None, None
-                self.logger.info(f"Unable to get firmware versions (attempt {query_retry_count + 1}/{query_retry_count_max}): {str(e)}, retrying...")
 
-            query_retry_count += 1
-            time.sleep(1)
+                sleep_time = min(delay, remaining)
+                error_str = str(e)
 
-        return None, None
+                if 'rc = 523' in error_str:
+                    self.logger.info(
+                        f"ASIC management interface not ready for {self.pci_id} "
+                        f"(MCAM rc=523): {error_str} "
+                        f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
+                    )
+                else:
+                    self.logger.info(
+                        f"Unable to get firmware versions for {self.pci_id} "
+                        f"(attempt {attempt}): {error_str} "
+                        f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
+                    )
+
+                time.sleep(sleep_time)
+                delay = min(delay * 2, max_delay)
 
     @abstractmethod
     def _get_available_firmware_version(self, psid: str) -> Optional[str]:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The firmware version query (`mlxfwmanager --query-format XML`) can fail transiently when the ASIC management interface is not yet ready (MCAM rc=523). The previous fixed 1s retry over 10 attempts (~10s) was insufficient for slow-initializing ASICs, and lacked diagnostic output to understand failures.

#### How I did it

- Pass `_get_env()` to the query command so `FLASH_ACCESS_DEBUG` / `FW_COMPS_DEBUG` are set when verbose mode is enabled.
- Extract `<Devices>...</Devices>` XML from stdout to handle verbose debug output mixed with the XML response.
- Replace fixed-interval retry with exponential backoff (1s → 2s → 4s → 8s → 16s cap) bounded by 60s total wall-clock time.
- Add specific log message when MCAM rc=523 is detected, identifying the ASIC management interface as not ready.
- Treat `current_version == '--'` as an invalid response (indicates device failed to open).

#### How to verify it

- Deploy to a switch and trigger FW query during ASIC init (rc=523 window). Verify logs show the MCAM-specific message with backoff timing.
- On a healthy switch, verify query succeeds on first attempt with debug output correctly parsed.
- Enable `--verbose` flag and confirm `FLASH_ACCESS_DEBUG`/`FW_COMPS_DEBUG` output does not break XML parsing.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

